### PR TITLE
Fix toast hook listener cleanup bug

### DIFF
--- a/hooks/use-toast.ts
+++ b/hooks/use-toast.ts
@@ -182,7 +182,7 @@ function useToast() {
         listeners.splice(index, 1)
       }
     }
-  }, [state])
+  }, [])
 
   return {
     ...state,


### PR DESCRIPTION
## Summary
- fix `useToast` effect dependencies to avoid listener leakage

## Testing
- `npm install --legacy-peer-deps`
- `npm run lint` *(fails: prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_683f6d9144148329b362547691659972